### PR TITLE
Fix getFlowFactor method

### DIFF
--- a/bin/calculations.js
+++ b/bin/calculations.js
@@ -886,7 +886,7 @@ var Biodiversity = function () {
 
     this.update = function (i) {
         if(year == 2) {
-            console.log(year);
+            //console.log(year);
         }
 
         setNativeVegetationArea(i);
@@ -1965,14 +1965,12 @@ var Erosion = function () {
     }
 
     function getFlowFactor(i) {
-        if (topoSlopeRangeHigh[i] <= 5 && drainageclass[i] >= 60) {
-            if (subsoilGroup[i] == 1 || subsoilGroup[i] == 2) {
-                return 0.1;
-            } else if (permeabilityCode[i] <= 35 || permeabilityCode == 58 || permeabilityCode[i] == 72 || permeabilityCode[i] == 75) {
-                return 0.1;
-            }
+        if(topoSlopeRangeHigh[i] <= 5 && drainageclass[i] >= 60 && (subsoilGroup[i] == 1 || subsoilGroup[i] == 2)){
+          return 0.1;
+        } else if (permeabilityCode[i] <= 35 || permeabilityCode[i] == 58 || permeabilityCode[i] == 72 || permeabilityCode[i] == 75) {
+          return 0.1;
         } else {
-            return 0;
+          return 0;
         }
     } // For every land cover point
 


### PR DESCRIPTION
While running a test for Phosphorus output, the Runoff Component was identified as causing an error in output for Phosphorus Test 1.5. Runoff Component calls the getFlowFactor method, which in this case was causing the error. 

Previous implementation used a nested conditional statement to implement the Options 1 and 2 as described on page 72 in the manual. This implementation nested Option 2 inside of Option 1 which caused some cases of input to be directed to the else{} statement rather than satisfying the conditions of Option 2. 

Current implementation first checks all criteria for Option 1, then all criteria for Option 2, before entering the else{} statement.
